### PR TITLE
Update output reader and image buffer settings

### DIFF
--- a/Example/SwiftVideoGenerator/ViewController.swift
+++ b/Example/SwiftVideoGenerator/ViewController.swift
@@ -169,7 +169,7 @@ class ViewController: UIViewController {
   /// Reverses the given video
   /// - Parameter sender: a sender of type UIButton
   @IBAction func reverseVideoButtonClickHandler(_ sender: UIButton) {
-    if let videoURL1 = Bundle.main.url(forResource: "video1", withExtension: "mov") {
+    if let videoURL1 = Bundle.main.url(forResource: "video2", withExtension: "mov") {
       LoadingView.lockView()
       VideoGenerator.current.reverseVideo(fromVideo: videoURL1, andFileName: "reversedMovie", withSound: false, success: { (videoURL) in
         LoadingView.unlockView()

--- a/SwiftVideoGenerator/Classes/VideoGenerator.swift
+++ b/SwiftVideoGenerator/Classes/VideoGenerator.swift
@@ -802,7 +802,7 @@ public class VideoGenerator: NSObject {
                 
                 if samples.count > 1 {
                   
-                  writer = try AVAssetWriter(outputURL: completeMoviePath, fileType: .mp4)
+                  writer = try AVAssetWriter(outputURL: completeMoviePath, fileType: .m4v)
                   let writerInput = AVAssetWriterInput(mediaType: .video, outputSettings: videoSettings)
                   writerInput.expectsMediaDataInRealTime = false
                   

--- a/SwiftVideoGenerator/Classes/VideoGenerator.swift
+++ b/SwiftVideoGenerator/Classes/VideoGenerator.swift
@@ -765,21 +765,9 @@ public class VideoGenerator: NSObject {
             }
           }
           
-          /// create the basic video settings
-          let videoSettings: [String : AnyObject] = [
-            AVVideoCodecKey  : AVVideoCodecH264 as AnyObject,
-            AVVideoWidthKey  : videoSize.width as AnyObject,
-            AVVideoHeightKey : videoSize.height as AnyObject,
-            ]
-          
           /// create setting for the pixel buffer
-          let sourceBufferAttributes: [String : AnyObject] = [
-            (kCVPixelBufferPixelFormatTypeKey as String): Int(kCVPixelFormatType_32ARGB) as AnyObject,
-            (kCVPixelBufferWidthKey as String): Float(videoSize.width) as AnyObject,
-            (kCVPixelBufferHeightKey as String):  Float(videoSize.height) as AnyObject,
-            (kCVPixelBufferCGImageCompatibilityKey as String): NSNumber(value: true),
-            (kCVPixelBufferCGBitmapContextCompatibilityKey as String): NSNumber(value: true)
-          ]
+          
+          let sourceBufferAttributes: [String: Any] = [kCVPixelBufferPixelFormatTypeKey as String : Int(kCVPixelFormatType_420YpCbCr8BiPlanarFullRange)]
           
           var writer: AVAssetWriter!
           
@@ -787,6 +775,15 @@ public class VideoGenerator: NSObject {
             let reader = try AVAssetReader(asset: videoAsset)
             
             if let assetVideoTrack = videoAsset.tracks(withMediaType: .video).first {
+              
+              let videoCompositionProps = [AVVideoAverageBitRateKey: assetVideoTrack.estimatedDataRate]
+              /// create the basic video settings
+              let videoSettings: [String : Any] = [
+                AVVideoCodecKey  : AVVideoCodecH264,
+                AVVideoWidthKey  : videoSize.width,
+                AVVideoHeightKey : videoSize.height,
+                AVVideoCompressionPropertiesKey: videoCompositionProps
+              ]
               
               let readerOutput = AVAssetReaderTrackOutput(track: assetVideoTrack, outputSettings: sourceBufferAttributes)
               
@@ -805,7 +802,7 @@ public class VideoGenerator: NSObject {
                 
                 if samples.count > 1 {
                   
-                  writer = try AVAssetWriter(outputURL: completeMoviePath, fileType: .m4v)
+                  writer = try AVAssetWriter(outputURL: completeMoviePath, fileType: .mp4)
                   let writerInput = AVAssetWriterInput(mediaType: .video, outputSettings: videoSettings)
                   writerInput.expectsMediaDataInRealTime = false
                   


### PR DESCRIPTION
Changed the settings for the output reader and image buffer to prevent crashes for video clips shorter than 30 seconds