### PR TITLE
fixed problem with generating video more than once.

### DIFF
--- a/SwiftVideoGenerator/Classes/VideoGenerator.swift
+++ b/SwiftVideoGenerator/Classes/VideoGenerator.swift
@@ -213,8 +213,10 @@ public class VideoGenerator: NSObject {
                   
                   do {
                     let fileURLs = try FileManager.default.contentsOfDirectory(at: documentDirectory, includingPropertiesForKeys: nil)
+
+                    let newFileURLs = fileURLs.map { $0.standardizedFileURL }
                     
-                    if fileURLs.contains(newPath) {
+                    if newFileURLs.contains(newPath) {
                       try FileManager.default.removeItem(at: newPath)
                     }
                     


### PR DESCRIPTION
Fixed problem when generating a video more than once return error:
“test.m4v” couldn’t be moved to “Documents” because an item with the same name already exists."
Problem was in FileManager.default.contentsOfDirectory method which return an array of URLs with prefix private/.
And this condition always failed:
if newFileURLs.contains(newPath) {
                      try FileManager.default.removeItem(at: newPath)
                    }