### PR TITLE
Used AVAssetExportPresetPassthrough instead of AVAssetExportPresetHig…

### DIFF
--- a/SwiftVideoGenerator/Classes/VideoGenerator.swift
+++ b/SwiftVideoGenerator/Classes/VideoGenerator.swift
@@ -331,7 +331,7 @@ public class VideoGenerator: NSObject {
         }
         
         /// try to start an export session and set the path and file type
-        if let exportSession = AVAssetExportSession(asset: composition, presetName: AVAssetExportPresetHighestQuality) {
+        if let exportSession = AVAssetExportSession(asset: composition, presetName: AVAssetExportPresetPassthrough) {
           exportSession.outputURL = completeMoviePath
           exportSession.outputFileType = AVFileType.mp4
           exportSession.shouldOptimizeForNetworkUse = true


### PR DESCRIPTION
…hestQuality. According to apple docs: https://developer.apple.com/documentation/avfoundation/avassetexportsession/export_preset_names_for_device-appropriate_quicktime_files?changes=latest_minor