### PR TITLE
Prevent portrait video being rotated to landscape.

### DIFF
--- a/Sources/SwiftVideoGenerator/Classes/VideoGenerator.swift
+++ b/Sources/SwiftVideoGenerator/Classes/VideoGenerator.swift
@@ -494,6 +494,10 @@ public class VideoGenerator: NSObject {
     }
     
     if let aVideoAssetTrack: AVAssetTrack = aVideoAsset.tracks(withMediaType: .video).first, let aAudioAssetTrack: AVAssetTrack = aAudioAsset.tracks(withMediaType: .audio).first {
+      
+      //correct the AVAsset orientation
+        mutableCompositionVideoTrack.first?.preferredTransform = aVideoAssetTrack.preferredTransform
+      
       do {
         try mutableCompositionVideoTrack.first?.insertTimeRange(CMTimeRangeMake(start: CMTime.zero, duration: aVideoAssetTrack.timeRange.duration), of: aVideoAssetTrack, at: CMTime.zero)
         try mutableCompositionAudioTrack.first?.insertTimeRange(CMTimeRangeMake(start: CMTime.zero, duration: aVideoAssetTrack.timeRange.duration), of: aAudioAssetTrack, at: CMTime.zero)


### PR DESCRIPTION
Added a line to prevent portrait video being rotated to landscape by using the preferred transform of the aVideoAssetTrack.